### PR TITLE
Изменена функция contains и добавлены функции akeys и avals

### DIFF
--- a/config/hstore.yml
+++ b/config/hstore.yml
@@ -9,6 +9,8 @@ doctrine:
     orm:
         dql:
             string_functions:
+                akeys:            Intaro\HStore\Doctrine\Query\AKeysFunction
+                avals:            Intaro\HStore\Doctrine\Query\AValsFunction
                 contains:         Intaro\HStore\Doctrine\Query\ContainsFunction
                 defined:          Intaro\HStore\Doctrine\Query\DefinedFunction
                 existsAny:        Intaro\HStore\Doctrine\Query\ExistsAnyFunction

--- a/src/Doctrine/Query/AKeysFunction.php
+++ b/src/Doctrine/Query/AKeysFunction.php
@@ -5,17 +5,18 @@ namespace Intaro\HStore\Doctrine\Query;
 use Doctrine\ORM\Query\AST\Functions\FunctionNode;
 use Doctrine\ORM\Query\Lexer;
 
-class ContainsFunction extends FunctionNode
+/**
+ * Function akeys() gets hstore keys as array
+ */
+class AKeysFunction extends FunctionNode
 {
-    public $hstore1Expression = null;
-    public $hstore2Expression = null;
+    public $hstoreExpression = null;
 
     public function getSql(\Doctrine\ORM\Query\SqlWalker $sqlWalker)
     {
         return sprintf(
-            '(%s @> %s)',
-            $this->hstore1Expression->dispatch($sqlWalker),
-            $this->hstore2Expression->dispatch($sqlWalker)
+            'akeys(%s)',
+            $this->hstoreExpression->dispatch($sqlWalker)
         );
     }
 
@@ -23,9 +24,7 @@ class ContainsFunction extends FunctionNode
     {
         $parser->match(Lexer::T_IDENTIFIER);
         $parser->match(Lexer::T_OPEN_PARENTHESIS);
-        $this->hstore1Expression = $parser->ArithmeticPrimary();
-        $parser->match(Lexer::T_COMMA);
-        $this->hstore2Expression = $parser->ArithmeticPrimary();
+        $this->hstoreExpression = $parser->ArithmeticPrimary();
         $parser->match(Lexer::T_CLOSE_PARENTHESIS);
     }
 }

--- a/src/Doctrine/Query/AValsFunction.php
+++ b/src/Doctrine/Query/AValsFunction.php
@@ -5,17 +5,18 @@ namespace Intaro\HStore\Doctrine\Query;
 use Doctrine\ORM\Query\AST\Functions\FunctionNode;
 use Doctrine\ORM\Query\Lexer;
 
-class ContainsFunction extends FunctionNode
+/**
+ * Function avals() gets hstore values as array
+ */
+class AValsFunction extends FunctionNode
 {
-    public $hstore1Expression = null;
-    public $hstore2Expression = null;
+    public $hstoreExpression = null;
 
     public function getSql(\Doctrine\ORM\Query\SqlWalker $sqlWalker)
     {
         return sprintf(
-            '(%s @> %s)',
-            $this->hstore1Expression->dispatch($sqlWalker),
-            $this->hstore2Expression->dispatch($sqlWalker)
+            'avals(%s)',
+            $this->hstoreExpression->dispatch($sqlWalker)
         );
     }
 
@@ -23,9 +24,7 @@ class ContainsFunction extends FunctionNode
     {
         $parser->match(Lexer::T_IDENTIFIER);
         $parser->match(Lexer::T_OPEN_PARENTHESIS);
-        $this->hstore1Expression = $parser->ArithmeticPrimary();
-        $parser->match(Lexer::T_COMMA);
-        $this->hstore2Expression = $parser->ArithmeticPrimary();
+        $this->hstoreExpression = $parser->ArithmeticPrimary();
         $parser->match(Lexer::T_CLOSE_PARENTHESIS);
     }
 }

--- a/tests/Doctrine/HStoreTestCase.php
+++ b/tests/Doctrine/HStoreTestCase.php
@@ -22,6 +22,8 @@ class HStoreTestCase extends \PHPUnit_Framework_TestCase
         $config->addEntityNamespace('E', 'Intaro\HStore\Tests\Doctrine\Entities');
 
         $config->setCustomStringFunctions(array(
+            'akeys'            => 'Intaro\HStore\Doctrine\Query\AKeysFunction',
+            'avals'            => 'Intaro\HStore\Doctrine\Query\AValsFunction',
             'contains'         => 'Intaro\HStore\Doctrine\Query\ContainsFunction',
             'defined'          => 'Intaro\HStore\Doctrine\Query\DefinedFunction',
             'existsAny'        => 'Intaro\HStore\Doctrine\Query\ExistsAnyFunction',

--- a/tests/Doctrine/Query/FunctionsTest.php
+++ b/tests/Doctrine/Query/FunctionsTest.php
@@ -6,6 +6,30 @@ use Intaro\HStore\Tests\Doctrine\HStoreTestCase;
 
 class FunctionsTest extends HStoreTestCase
 {
+    public function testAKeys()
+    {
+        $q = $this
+            ->entityManager
+            ->createQuery("SELECT akeys(o.attrs) from E:Order o");
+
+        $this->assertEquals(
+            "SELECT akeys(o0_.attrs) AS sclr_0 FROM Order o0_",
+            $q->getSql()
+        );
+    }
+
+    public function testAVals()
+    {
+        $q = $this
+            ->entityManager
+            ->createQuery("SELECT avals(o.attrs) from E:Order o");
+
+        $this->assertEquals(
+            "SELECT avals(o0_.attrs) AS sclr_0 FROM Order o0_",
+            $q->getSql()
+        );
+    }
+
     public function testContains()
     {
         $q = $this
@@ -13,7 +37,7 @@ class FunctionsTest extends HStoreTestCase
             ->createQuery("SELECT contains(o.attrs, 'a') from E:Order o");
 
         $this->assertEquals(
-            "SELECT contains(o0_.attrs, 'a') AS sclr_0 FROM Order o0_",
+            "SELECT (o0_.attrs @> 'a') AS sclr_0 FROM Order o0_",
             $q->getSql()
         );
     }


### PR DESCRIPTION
Изменена функция contains: теперь используется оператор @> это позволяет использовать gist индексы.
